### PR TITLE
CORS Settings

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -40,9 +40,11 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'clashers_gg',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     # Manages sessions across requests
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -73,6 +75,15 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'api.wsgi.application'
+
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:8080",
+]
+CORS_ALLOW_CREDENTIALS = True
+
+CSRF_TRUSTED_ORIGINS = [
+    "http://localhost:8080",
+]
 
 
 # Database


### PR DESCRIPTION
Closes #7 

In `settings.py`, added `CORS_ALLOWED_ORIGINS` and `CORS_TRUSTED_ORIGINS` to allow localhost:8080 to be recognized as a valid address by CORS. On the frontend side, this allows user data to be authenticated. 